### PR TITLE
Update linux_func.c

### DIFF
--- a/kernel/linux_func.c
+++ b/kernel/linux_func.c
@@ -1886,7 +1886,7 @@ class_destroy(struct class *class)
 int
 alloc_chrdev_region(dev_t *pdev, unsigned basemin, unsigned count, const char *name)
 {
-	if (strcmp(name, "BaseRemoteCtl") == 0) {
+	if (strcmp(name, "lirc") == 0) {
 		*pdev = MKDEV(LIRC_MAJOR, basemin);
 		return (0);
 	} else if (strcmp(name, "roccat") == 0) {


### PR DESCRIPTION
media code changed from BaseRemoteCtl to lirc for this string in https://github.com/torvalds/linux/commit/32c3db3d9873ef822a9544259d68d0cd31c7bc64

change this, so that lirc devices continue to work (tested with mceusb)